### PR TITLE
Update module_options.php

### DIFF
--- a/views/admin/en/module_options.php
+++ b/views/admin/en/module_options.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * @package   ocb_cleartmp


### PR DESCRIPTION
Empty first line before <?php causes empty white page in Oxid eShop registration process for new users if smarty cache is empty.

Apache php error log: 
PHP Warning:  Cannot modify header information - headers already sent by (output started at /www/htdocs/.../source/modules/oxcom/ocbcleartmp/views/admin/en/module_options.php:1) in ...